### PR TITLE
Update for Minecraft 1.20.5/6, fixes #19

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.elmakers.mine.bukkit</groupId>
 	<artifactId>EffectLib</artifactId>
-	<version>10.2</version>
+	<version>10.3</version>
 
 	<name>EffectLib</name>
 	<description>A library for Bukkit plugins to make complicated particle effects</description>
@@ -73,11 +73,10 @@
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
+			<!--<version>1.20.5-R0.1-SNAPSHOT</version>-->
 			<version>1.19.3-R0.1-SNAPSHOT</version>
-			<!-- for testing backwards-compat
-			<version>1.13-R0.1-SNAPSHOT</version>
-			<version>1.9-R0.1-SNAPSHOT</version>
-			-->
+			<!--<version>1.13-R0.1-SNAPSHOT</version>-->
+			<!--<version>1.9-R0.1-SNAPSHOT</version>-->
 			<scope>provided</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,6 @@
 			<version>1.0</version>
 			<scope>compile</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.12.0</version>
-		</dependency>
 	</dependencies>
 
 	<build>
@@ -107,8 +102,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>7</source>
-					<target>7</target>
+					<source>8</source>
+					<target>8</target>
 				</configuration>
 			</plugin>
 

--- a/src/main/java/de/slikey/effectlib/math/EquationStore.java
+++ b/src/main/java/de/slikey/effectlib/math/EquationStore.java
@@ -4,8 +4,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Collection;
 
-import org.apache.commons.lang3.StringUtils;
-
 public class EquationStore {
 
     private static final String DEFAULT_VARIABLE = "x";
@@ -27,7 +25,7 @@ public class EquationStore {
     }
 
     public EquationTransform getTransform(String equation, String... variables) {
-        String equationKey = equation + ":" + StringUtils.join(variables, ",");
+        String equationKey = equation + ":" + String.join(",", variables);
         EquationTransform transform = transforms.get(equationKey);
         if (transform == null) {
             transform = new EquationTransform(equation, variables);
@@ -38,7 +36,7 @@ public class EquationStore {
     }
 
     public EquationTransform getTransform(String equation, Collection<String> variables) {
-        String equationKey = equation + ":" + StringUtils.join(variables, ",");
+        String equationKey = equation + ":" + String.join(",", variables);
         EquationTransform transform = transforms.get(equationKey);
         if (transform == null) {
             transform = new EquationTransform(equation, variables);

--- a/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
+++ b/src/main/java/de/slikey/effectlib/util/BaseImageEffect.java
@@ -20,7 +20,7 @@ public abstract class BaseImageEffect extends Effect {
     public String fileName = null;
 
     /**
-     * Whether or not to check for transparent pixels
+     * Whether to check for transparent pixels
      */
     public boolean transparency = false;
 
@@ -109,7 +109,11 @@ public abstract class BaseImageEffect extends Effect {
     public BaseImageEffect(EffectManager effectManager) {
         super(effectManager);
         type = EffectType.REPEATING;
-        particle = Particle.REDSTONE;
+        try {
+            particle = Particle.REDSTONE;
+        } catch (IllegalArgumentException e) {
+            particle = Particle.valueOf("DUST");
+        }
         period = 2;
         iterations = 200;
     }

--- a/src/main/java/de/slikey/effectlib/util/CustomSound.java
+++ b/src/main/java/de/slikey/effectlib/util/CustomSound.java
@@ -12,8 +12,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 
-import org.apache.commons.lang3.StringUtils;
-
 public class CustomSound {
     private static boolean initializedReflection;
     private static Method player_playCustomSoundMethod;
@@ -36,7 +34,7 @@ public class CustomSound {
      */
     public CustomSound(String key) {
         if (key != null && key.length() > 0) {
-            String[] pieces = StringUtils.split(key, ',');
+            String[] pieces = key.split(",");
             String soundName = pieces[0];
 
             if (soundName.indexOf('.') < 0) {

--- a/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
+++ b/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
@@ -2,6 +2,7 @@ package de.slikey.effectlib.util;
 
 import java.util.List;
 
+import de.slikey.effectlib.util.versions.ParticleDisplay_20_5;
 import org.bukkit.Color;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -93,20 +94,26 @@ public abstract class ParticleDisplay {
         ParticleDisplay display;
 
         try {
-            Particle.valueOf("SHRIEK");
-            display = new ParticleDisplay_19();
+            Particle.valueOf("DUST");
+            display = new ParticleDisplay_20_5();
             hasColorTransition = true;
-        } catch (Throwable not19) {
+        } catch (Throwable not20_5) {
             try {
-                Particle.valueOf("VIBRATION");
-                display = new ParticleDisplay_17();
+                Particle.valueOf("SHRIEK");
+                display = new ParticleDisplay_19();
                 hasColorTransition = true;
-            } catch (Throwable not17) {
+            } catch (Throwable not19) {
                 try {
-                    Particle.valueOf("SQUID_INK");
-                    display = new ParticleDisplay_13();
-                } catch (Throwable not13) {
-                    display = new ParticleDisplay_12();
+                    Particle.valueOf("VIBRATION");
+                    display = new ParticleDisplay_17();
+                    hasColorTransition = true;
+                } catch (Throwable not17) {
+                    try {
+                        Particle.valueOf("SQUID_INK");
+                        display = new ParticleDisplay_13();
+                    } catch (Throwable not13) {
+                        display = new ParticleDisplay_12();
+                    }
                 }
             }
         }

--- a/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
+++ b/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
@@ -22,6 +22,7 @@ public abstract class ParticleDisplay {
     protected EffectManager manager;
 
     private static boolean hasColorTransition = false;
+    private static boolean hasColorDataType = false;
 
     public abstract void display(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers);
 
@@ -32,10 +33,9 @@ public abstract class ParticleDisplay {
                 for (final Player player : Bukkit.getOnlinePlayers()) {
                     if (!manager.isVisiblePlayer(player, center, squared)) continue;
 
-                    try {
-                        Particle.valueOf("DUST");
+                    if (hasColorDataType && particle == Particle.valueOf("ENTITY_EFFECT")) {
                         player.spawnParticle(particle, center, options.amount, options.offsetX, options.offsetY, options.offsetZ, options.speed, options.color);
-                    } catch (Throwable not20_5) {
+                    } else {
                         player.spawnParticle(particle, center, options.amount, options.offsetX, options.offsetY, options.offsetZ, options.speed, options.data);
                     }
 
@@ -103,6 +103,7 @@ public abstract class ParticleDisplay {
             Particle.valueOf("DUST");
             display = new ParticleDisplay_20_5();
             hasColorTransition = true;
+            hasColorDataType = true;
         } catch (Throwable not20_5) {
             try {
                 Particle.valueOf("SHRIEK");

--- a/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
+++ b/src/main/java/de/slikey/effectlib/util/ParticleDisplay.java
@@ -32,7 +32,13 @@ public abstract class ParticleDisplay {
                 for (final Player player : Bukkit.getOnlinePlayers()) {
                     if (!manager.isVisiblePlayer(player, center, squared)) continue;
 
-                    player.spawnParticle(particle, center, options.amount, options.offsetX, options.offsetY, options.offsetZ, options.speed, options.data);
+                    try {
+                        Particle.valueOf("DUST");
+                        player.spawnParticle(particle, center, options.amount, options.offsetX, options.offsetY, options.offsetZ, options.speed, options.color);
+                    } catch (Throwable not20_5) {
+                        player.spawnParticle(particle, center, options.amount, options.offsetX, options.offsetY, options.offsetZ, options.speed, options.data);
+                    }
+
                     displayFakeBlock(player, center, options);
                 }
                 return;

--- a/src/main/java/de/slikey/effectlib/util/versions/ParticleDisplay_17.java
+++ b/src/main/java/de/slikey/effectlib/util/versions/ParticleDisplay_17.java
@@ -2,6 +2,7 @@ package de.slikey.effectlib.util.versions;
 
 import java.util.List;
 
+import de.slikey.effectlib.util.ParticleDisplay;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -12,7 +13,7 @@ import org.bukkit.entity.Player;
 
 import de.slikey.effectlib.util.ParticleOptions;
 
-public class ParticleDisplay_17 extends ParticleDisplay_13 {
+public class ParticleDisplay_17 extends ParticleDisplay {
 
     @Override
     public void display(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {

--- a/src/main/java/de/slikey/effectlib/util/versions/ParticleDisplay_20_5.java
+++ b/src/main/java/de/slikey/effectlib/util/versions/ParticleDisplay_20_5.java
@@ -1,8 +1,7 @@
 package de.slikey.effectlib.util.versions;
 
-import java.util.List;
-
 import de.slikey.effectlib.util.ParticleDisplay;
+import de.slikey.effectlib.util.ParticleOptions;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -11,24 +10,26 @@ import org.bukkit.Vibration;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
-import de.slikey.effectlib.util.ParticleOptions;
+import java.util.List;
 
-public class ParticleDisplay_19 extends ParticleDisplay {
+public class ParticleDisplay_20_5 extends ParticleDisplay {
 
 	@Override
 	public void display(Particle particle, ParticleOptions options, Location center, double range, List<Player> targetPlayers) {
 		// Legacy colorizeable particles
-		if (options.color != null && (particle == Particle.SPELL_MOB || particle == Particle.SPELL_MOB_AMBIENT)) {
+		// 1.20.5 has removed Particle#SPELL_MOB_AMBIENT and SPELL_MOB is now ENTITY_EFFECT
+		if (options.color != null && (particle == Particle.valueOf("ENTITY_EFFECT"))) {
 			displayLegacyColored(particle, options, center, range, targetPlayers);
 			return;
 		}
 
-		if (particle == Particle.ITEM_CRACK) {
+		if (particle == Particle.valueOf("ITEM")) {
 			displayItem(particle, options, center, range, targetPlayers);
 			return;
 		}
 
-		if (particle == Particle.BLOCK_CRACK || particle == Particle.BLOCK_DUST || particle == Particle.FALLING_DUST) {
+		// 1.20.5 has removed Particle#BLOCK_DUST
+		if (particle == Particle.valueOf("BLOCK") || particle == Particle.FALLING_DUST) {
 			Material material = options.material;
 			if (material == null || material.name().contains("AIR")) return;
 			try {
@@ -39,7 +40,7 @@ public class ParticleDisplay_19 extends ParticleDisplay {
 			if (options.data == null) return;
 		}
 
-		if (particle == Particle.REDSTONE) {
+		if (particle == Particle.valueOf("DUST")) {
 			// color is required
 			if (options.color == null) options.color = Color.RED;
 			options.data = new Particle.DustOptions(options.color, options.size);


### PR DESCRIPTION
I've put some work in on getting the library compatible with the latest Minecraft versions. I've checked that the basics work, but you'll want to check on some of the more complex particles.

This avoids using an external library like [FastParticles](https://github.com/MrMicky-FR/FastParticles), but doesn't protect against future changes. [Here](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/bukkit/diff/src/main/java/org/bukkit/Particle.java?until=8a34e009148cc297bcc9eb5c250fc4f5b071c4a7) are the particle field changes introduced in 1.20.5, for your convenience.