### PR TITLE
Call super.reset() for CircleEffect

### DIFF
--- a/EffectLib/src/main/java/de/slikey/effectlib/effect/CircleEffect.java
+++ b/EffectLib/src/main/java/de/slikey/effectlib/effect/CircleEffect.java
@@ -89,6 +89,7 @@ public class CircleEffect extends Effect {
 
     @Override
     public void reset() {
+        super.reset();
         step = 0;
     }
 


### PR DESCRIPTION
This should now reset the `done` field in the `Effect` superclass so the effect can be reused.