### PR TITLE
assign color data if required by Particle

### DIFF
--- a/Compatibility/modern/src/main/java/de/slikey/effectlib/util/versions/ParticleDisplay_Modern.java
+++ b/Compatibility/modern/src/main/java/de/slikey/effectlib/util/versions/ParticleDisplay_Modern.java
@@ -56,6 +56,11 @@ public class ParticleDisplay_Modern extends ParticleDisplay {
             options.data = new Particle.DustTransition(options.color, options.toColor, options.size);
         }
 
+        if (dataType != null && dataType.isAssignableFrom(Color.class)) {
+            if (options.color == null) options.color = Color.RED;
+            options.data = options.color;
+        }
+
         if (dataType != null && dataType.isAssignableFrom(Vibration.class)) {
             if (options.target == null) return;
 


### PR DESCRIPTION
For tinted_leaves particle introduced in mc 1.21.5, which requires a Color data type instance.

Tested in paper 1.21.8.